### PR TITLE
feat: click sub-theme in leaderboard to show stock list modal

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2382,9 +2382,9 @@ const MarketInternalsV2 = ({ mc, internalsData }) => {
             <span className="text-zinc-500">ADV/DEC</span>
             {adv_dec ? (
               <span className="font-mono font-semibold">
-                <span className="text-emerald-400">{adv_dec.adv_pct?.toFixed(1)}%</span>
+                <span className="text-emerald-300">{adv_dec.adv_pct?.toFixed(1)}%</span>
                 <span className="text-zinc-500"> ({adv_dec.advancing}) / </span>
-                <span className="text-red-400">{adv_dec.dec_pct?.toFixed(1)}%</span>
+                <span className="text-red-300">{adv_dec.dec_pct?.toFixed(1)}%</span>
                 <span className="text-zinc-500"> ({adv_dec.declining})</span>
               </span>
             ) : <span className={`font-mono font-semibold ${advCls}`}>—</span>}

--- a/src/App.js
+++ b/src/App.js
@@ -2266,27 +2266,27 @@ const INTERNALS_NOTES = [
     label: "ADV/DEC",
     desc: "Advancing / Declining stocks ratio",
     lines: [
-      { text: "≥60% advancing → healthy breadth", active: v => v >= 60 },
-      { text: "40–60% → neutral, be selective", active: v => v >= 40 && v < 60 },
-      { text: "<40% → bad breadth, avoid chasing", active: v => v < 40 },
+      { text: "≥60% advancing → healthy breadth", active: v => v >= 60, signal: "green" },
+      { text: "40–60% → neutral, be selective", active: v => v >= 40 && v < 60, signal: "yellow" },
+      { text: "<40% → bad breadth, avoid chasing", active: v => v < 40, signal: "red" },
     ],
   },
   {
     label: "SMA50 ↑",
     desc: "% of stocks above 50-day MA",
     lines: [
-      { text: "≥60% → bull momentum healthy", active: v => v >= 60 },
-      { text: "40–60% → borderline, buy leaders only", active: v => v >= 40 && v < 60 },
-      { text: "<40% → weak market internals", active: v => v < 40 },
+      { text: "≥60% → bull momentum healthy", active: v => v >= 60, signal: "green" },
+      { text: "40–60% → borderline, buy leaders only", active: v => v >= 40 && v < 60, signal: "yellow" },
+      { text: "<40% → weak market internals", active: v => v < 40, signal: "red" },
     ],
   },
   {
     label: "SMA200 ↑",
     desc: "% of stocks above 200-day MA",
     lines: [
-      { text: "≥60% → long-term bull structure", active: v => v >= 60 },
-      { text: "50–60% → caution zone", active: v => v >= 50 && v < 60 },
-      { text: "<50% → majority in downtrend", active: v => v < 50 },
+      { text: "≥60% → long-term bull structure", active: v => v >= 60, signal: "green" },
+      { text: "50–60% → caution zone", active: v => v >= 50 && v < 60, signal: "yellow" },
+      { text: "<50% → majority in downtrend", active: v => v < 50, signal: "red" },
     ],
   },
   {
@@ -2294,44 +2294,44 @@ const INTERNALS_NOTES = [
     desc: "Stocks making 52-week highs",
     lines: [
       { text: "More highs = stronger bull momentum" },
-      { text: "Healthy: Hi/Lo ratio >5", active: v => v > 5 },
+      { text: "Healthy: Hi/Lo ratio >5", active: v => v > 5, signal: "green" },
     ],
   },
   {
     label: "52W Lo",
     desc: "Stocks making 52-week lows",
     lines: [
-      { text: "Low number = limited panic", active: v => v < 50 },
-      { text: "Sudden spike in Lo → market breakdown", active: v => v >= 100 },
+      { text: "Low number = limited panic", active: v => v < 50, signal: "green" },
+      { text: "Sudden spike in Lo → market breakdown", active: v => v >= 100, signal: "red" },
     ],
   },
   {
     label: "TICK",
     desc: "NYSE intraday upticks minus downticks",
     lines: [
-      { text: ">+800 → institutional buying, very strong", active: v => v > 800 },
-      { text: "+200 to +800 → bullish", active: v => v >= 200 && v <= 800 },
-      { text: "-200 to +200 → neutral", active: v => v > -200 && v < 200 },
-      { text: "<-800 → panic selling", active: v => v < -800 },
+      { text: ">+800 → institutional buying, very strong", active: v => v > 800, signal: "green" },
+      { text: "+200 to +800 → bullish", active: v => v >= 200 && v <= 800, signal: "green" },
+      { text: "-200 to +200 → neutral", active: v => v > -200 && v < 200, signal: "yellow" },
+      { text: "<-800 → panic selling", active: v => v < -800, signal: "red" },
     ],
   },
   {
     label: "TRIN",
     desc: "Arms Index — volume-weighted adv/dec ratio",
     lines: [
-      { text: "<0.7 → volume in advancing stocks → Buy", active: v => v < 0.7 },
-      { text: "0.7–1.3 → neutral", active: v => v >= 0.7 && v <= 1.3 },
-      { text: ">1.3 → volume in declining stocks → Sell", active: v => v > 1.3 && v <= 2.0 },
-      { text: ">2.0 → extreme panic, oversold bounce possible", active: v => v > 2.0 },
+      { text: "<0.7 → volume in advancing stocks → Buy", active: v => v < 0.7, signal: "green" },
+      { text: "0.7–1.3 → neutral", active: v => v >= 0.7 && v <= 1.3, signal: "yellow" },
+      { text: ">1.3 → volume in declining stocks → Sell", active: v => v > 1.3 && v <= 2.0, signal: "red" },
+      { text: ">2.0 → extreme panic, oversold bounce possible", active: v => v > 2.0, signal: "red" },
     ],
   },
   {
     label: "T2108",
     desc: "% of stocks above 40-day MA (Worden)",
     lines: [
-      { text: "<20% → oversold, look for bounce", active: v => v < 20 },
-      { text: "20–70% → normal range", active: v => v >= 20 && v <= 70 },
-      { text: ">70% → overbought, watch for pullback", active: v => v > 70 },
+      { text: "<20% → oversold, look for bounce", active: v => v < 20, signal: "yellow" },
+      { text: "20–70% → normal range", active: v => v >= 20 && v <= 70, signal: "green" },
+      { text: ">70% → overbought, watch for pullback", active: v => v > 70, signal: "red" },
     ],
   },
 ];
@@ -2383,9 +2383,9 @@ const MarketInternalsV2 = ({ mc, internalsData }) => {
             {adv_dec ? (
               <span className="font-mono font-semibold">
                 <span className="text-emerald-300">{adv_dec.adv_pct?.toFixed(1)}%</span>
-                <span className="text-zinc-500"> ({adv_dec.advancing}) / </span>
+                <span className="text-emerald-300"> ({adv_dec.advancing}) / </span>
                 <span className="text-red-300">{adv_dec.dec_pct?.toFixed(1)}%</span>
-                <span className="text-zinc-500"> ({adv_dec.declining})</span>
+                <span className="text-red-300"> ({adv_dec.declining})</span>
               </span>
             ) : <span className={`font-mono font-semibold ${advCls}`}>—</span>}
           </div>
@@ -2433,22 +2433,31 @@ const MarketInternalsV2 = ({ mc, internalsData }) => {
               const { raw, display } = noteVals[n.label] || {};
               return (
                 <div key={n.label} className="border-b border-zinc-800/40 pb-1.5 last:border-0 last:pb-0">
-                  <div className="flex items-baseline justify-between mb-0.5">
-                    <span className="text-[10px] font-semibold text-zinc-200">{n.label}</span>
-                    {display != null && <span className="text-[9px] font-mono text-amber-300">{display}</span>}
-                  </div>
-                  <ul className="space-y-0.5">
-                    {n.lines.map((l, i) => {
-                      const isActive = raw != null && l.active && l.active(raw);
-                      return (
-                        <li key={i} className={`text-[9px] leading-snug pl-1 before:content-['·'] before:mr-1 ${
-                          isActive
-                            ? "text-white font-semibold before:text-amber-400"
-                            : "text-zinc-500 before:text-zinc-700"
-                        }`}>{l.text}</li>
-                      );
-                    })}
-                  </ul>
+                  {(() => {
+                    const activeLine = raw != null ? n.lines.find(l => l.active && l.active(raw)) : null;
+                    const sig = activeLine?.signal;
+                    const sigCls = sig === "green" ? "text-emerald-400" : sig === "yellow" ? "text-amber-400" : sig === "red" ? "text-red-400" : "text-zinc-500";
+                    const dotCls = sig === "green" ? "before:text-emerald-400" : sig === "yellow" ? "before:text-amber-400" : sig === "red" ? "before:text-red-400" : "before:text-amber-400";
+                    return (
+                      <>
+                      <div className="flex items-baseline justify-between mb-0.5">
+                        <span className="text-[10px] font-semibold text-zinc-200">{n.label}</span>
+                        {display != null && <span className={`text-[9px] font-mono ${sigCls}`}>{display}</span>}
+                      </div>
+                      <ul className="space-y-0.5">
+                        {n.lines.map((l, i) => {
+                          const isActive = raw != null && l.active && l.active(raw);
+                          const lineDot = isActive ? dotCls : "before:text-zinc-700";
+                          return (
+                            <li key={i} className={`text-[9px] leading-snug pl-1 before:content-['·'] before:mr-1 ${
+                              isActive ? `font-semibold ${sigCls} ${lineDot}` : "text-zinc-500 before:text-zinc-700"
+                            }`}>{l.text}</li>
+                          );
+                        })}
+                      </ul>
+                      </>
+                    );
+                  })()}
                 </div>
               );
             });

--- a/src/App.js
+++ b/src/App.js
@@ -7283,13 +7283,14 @@ const filtered = useMemo(() => {
             if (!todayEvents.length) return null;
             return (
               <div className="hidden lg:flex items-center gap-1 text-[11px] font-mono py-0.5 border-t border-zinc-800/40 flex-wrap overflow-hidden">
-                <span className="text-zinc-600 font-semibold mr-1 whitespace-nowrap">ECON TODAY →</span>
+                <span className="text-amber-400 font-bold mr-1 whitespace-nowrap tracking-wide">ECON TODAY</span>
+                <span className="text-zinc-600 mr-1">→</span>
                 {todayEvents.map((ev, idx) => (
                   <React.Fragment key={idx}>
                     <span className="flex items-center gap-1 whitespace-nowrap">
-                      {ev.time && <span className="text-zinc-600">{ev.time}</span>}
-                      <span className="text-zinc-400">{ev.event || ev.name}</span>
-                      {ev.estimate != null && <span className="text-zinc-600">Est {ev.estimate}</span>}
+                      {ev.time && <span className="text-zinc-500">{ev.time}</span>}
+                      <span className="text-zinc-300">{(ev.event || ev.name || '').replace(/\s+Index$/i, '')}</span>
+                      {ev.estimate != null && <span className="text-zinc-500">Est {ev.estimate}</span>}
                     </span>
                     {idx < todayEvents.length - 1 && <Sep/>}
                   </React.Fragment>

--- a/src/App.js
+++ b/src/App.js
@@ -876,12 +876,86 @@ const ThemeHeatmap = ({ themes, finvizThemeRankings }) => {
   );
 };
 
+const SubThemeStocksModal = ({ subthemeName, stocks, onClose }) => {
+  const sorted = useMemo(() => [...stocks].sort((a, b) => (b.rs_52w ?? 0) - (a.rs_52w ?? 0)), [stocks]);
+  const [hovered, setHovered] = useState(null); // { ticker, rect }
+
+  useEffect(() => {
+    const handler = (e) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-[9998] flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={onClose}>
+      <div className="relative w-full max-w-2xl max-h-[80vh] bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl flex flex-col overflow-hidden" onClick={e => e.stopPropagation()}>
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800 shrink-0">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-zinc-100">{subthemeName}</span>
+            <span className="text-xs text-zinc-500 bg-zinc-800 px-1.5 py-0.5 rounded">{sorted.length} stocks · sorted by RS</span>
+          </div>
+          <button onClick={onClose} className="text-zinc-500 hover:text-zinc-300 transition-colors p-1 rounded hover:bg-zinc-800">
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none"><path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round"/></svg>
+          </button>
+        </div>
+        {/* Table */}
+        <div className="overflow-y-auto flex-1 px-2 py-1">
+          <table className="w-full border-collapse text-left text-xs">
+            <thead className="sticky top-0 bg-zinc-900 z-10">
+              <tr className="border-b border-zinc-800 text-zinc-500">
+                <th className="w-8 py-2 pr-2 text-right font-medium">#</th>
+                <th className="px-2 py-2 font-medium">Ticker</th>
+                <th className="px-2 py-2 font-medium">Company</th>
+                <th className="px-2 py-2 font-medium text-right">RS</th>
+                <th className="px-2 py-2 font-medium text-right">ADR%</th>
+                <th className="px-2 py-2 font-medium text-right">$ Vol</th>
+                <th className="px-2 py-2 font-medium text-right">1D Change%</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((s, i) => {
+                const rsCls = s.rs_52w >= 90 ? "text-emerald-300" : s.rs_52w >= 70 ? "text-emerald-400" : s.rs_52w >= 50 ? "text-zinc-300" : "text-red-400";
+                const chgCls = (s.change_pct ?? 0) > 0 ? "text-emerald-400" : (s.change_pct ?? 0) < 0 ? "text-red-400" : "text-zinc-400";
+                const fmtVol = (v) => { if (v == null) return "—"; if (v >= 1e9) return `$${(v/1e9).toFixed(1)}B`; if (v >= 1e6) return `$${(v/1e6).toFixed(0)}M`; return `$${(v/1e3).toFixed(0)}K`; };
+                const fmtPct = (v) => v == null ? "—" : `${v > 0 ? "+" : ""}${v.toFixed(2)}%`;
+                return (
+                  <tr key={s.ticker} className="border-b border-zinc-800/50 hover:bg-zinc-800/30 cursor-pointer"
+                    onClick={e => {
+                      const rect = e.currentTarget.getBoundingClientRect();
+                      setHovered(h => h?.ticker === s.ticker ? null : { ticker: s.ticker, rect });
+                    }}>
+                    <td className="py-1.5 pr-2 text-right font-mono text-zinc-600">{i + 1}</td>
+                    <td className="px-2 py-1.5 font-mono font-semibold text-cyan-400">{s.ticker}</td>
+                    <td className="px-2 py-1.5 text-zinc-300 max-w-[180px] truncate">{s.company || "—"}</td>
+                    <td className={`px-2 py-1.5 text-right font-mono font-bold ${rsCls}`}>{s.rs_52w ?? "—"}</td>
+                    <td className="px-2 py-1.5 text-right font-mono text-zinc-300">{s.adr_pct != null ? `${s.adr_pct.toFixed(1)}%` : "—"}</td>
+                    <td className="px-2 py-1.5 text-right font-mono text-zinc-400">{fmtVol(s.dollar_volume)}</td>
+                    <td className={`px-2 py-1.5 text-right font-mono font-semibold ${chgCls}`}>{fmtPct(s.change_pct)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+            <tfoot>
+              <tr className="border-t border-zinc-700 text-zinc-600 text-xs">
+                <td colSpan={7} className="py-1.5 pr-2 text-right font-mono">{sorted.length} stocks</td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+      {hovered && <TVPopup ticker={hovered.ticker} anchorRect={hovered.rect} onClose={() => setHovered(null)}/>}
+    </div>
+  );
+};
+
 const Leaderboard = ({ themeRankings, industryRankings, finvizThemeRankings, themes = [], themeSparklines = {}, ibkrThemesData, onViewChange, onThemeSelect }) => {
   const [sortPriority, setSortPriority] = useState([{ key: 'rs_score', direction: 'desc' }]);
   const [expanded, setExpanded] = useState(null);
   const [view, setView] = useState("themes"); // "themes" (Finviz map) or "industry"
   const [themeHover, setThemeHover] = useState(null); // { ticker, rect }
   const [themeStats, setThemeStats] = useState(null); // { themeName, anchorRect }
+  const [subThemeModal, setSubThemeModal] = useState(null); // { subthemeName, stocks }
 
   const activeData = view === "themes" ? finvizThemeRankings : themeRankings;
 
@@ -1102,8 +1176,26 @@ const Leaderboard = ({ themeRankings, industryRankings, finvizThemeRankings, the
                   {view === "themes" && (
                     <>
                       <td className="px-2 py-1.5 min-w-[120px]">
-                        <div className="text-[11px] text-zinc-400 leading-tight">
-                          {subThemeNames.join(' · ') || <span className="text-zinc-600">—</span>}
+                        <div className="text-[11px] text-zinc-400 leading-tight flex flex-wrap gap-x-1 gap-y-0.5">
+                          {subThemeNames.length === 0
+                            ? <span className="text-zinc-600">—</span>
+                            : subThemeNames.map((sn, si) => {
+                                const matchedTheme = themes.find(th => (th.name || '').toLowerCase() === (t.name || '').toLowerCase());
+                                const subObj = matchedTheme?.subthemes?.find(s => s.name === sn);
+                                return (
+                                  <React.Fragment key={sn}>
+                                    {si > 0 && <span className="text-zinc-700">·</span>}
+                                    <button
+                                      className="hover:text-blue-400 hover:underline transition-colors cursor-pointer"
+                                      onClick={e => {
+                                        e.stopPropagation();
+                                        if (subObj) setSubThemeModal({ subthemeName: sn, stocks: subObj.stocks || [] });
+                                      }}
+                                    >{sn}</button>
+                                  </React.Fragment>
+                                );
+                              })
+                          }
                         </div>
                       </td>
                       <td className="px-2 py-1.5">
@@ -1145,6 +1237,7 @@ const Leaderboard = ({ themeRankings, industryRankings, finvizThemeRankings, the
     </div>
     {themeHover && <TVPopup ticker={themeHover.ticker} anchorRect={themeHover.rect} onClose={() => { setThemeHover(null); setThemeStats(null); }}/>}
     {themeStats && <ThemeStatsPopup themeName={themeStats.themeName} themes={themes} anchorRect={themeStats.anchorRect} chartAnchor={themeHover?.rect} onClose={() => { setThemeStats(null); setThemeHover(null); }}/>}
+    {subThemeModal && <SubThemeStocksModal subthemeName={subThemeModal.subthemeName} stocks={subThemeModal.stocks} onClose={() => setSubThemeModal(null)}/>}
     </>
   );
 };

--- a/src/App.js
+++ b/src/App.js
@@ -2378,7 +2378,17 @@ const MarketInternalsV2 = ({ mc, internalsData }) => {
       </div>
       <div className="space-y-1.5">
         <div>
-          <div className="flex items-baseline justify-between text-[10px]"><span className="text-zinc-500">ADV/DEC</span><span className={`font-mono font-semibold ${advCls}`}>{advTxt}</span></div>
+          <div className="flex items-baseline justify-between text-[10px]">
+            <span className="text-zinc-500">ADV/DEC</span>
+            {adv_dec ? (
+              <span className="font-mono font-semibold">
+                <span className="text-emerald-400">{adv_dec.adv_pct?.toFixed(1)}%</span>
+                <span className="text-zinc-500"> ({adv_dec.advancing}) / </span>
+                <span className="text-red-400">{adv_dec.dec_pct?.toFixed(1)}%</span>
+                <span className="text-zinc-500"> ({adv_dec.declining})</span>
+              </span>
+            ) : <span className={`font-mono font-semibold ${advCls}`}>—</span>}
+          </div>
           <div className="h-1.5 rounded-full bg-zinc-800 overflow-hidden mt-0.5"><div className={`h-full ${advBar}`} style={{ width: `${Math.min(100, Math.max(0, advPct))}%` }}/></div>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- Sub-theme names in Theme Leaderboard are now clickable buttons
- Clicking opens a modal showing all stocks in that sub-theme, sorted by RS (highest first)
- Modal columns: #, Ticker, Company, RS, ADR%, $ Vol, 1D Change% — same style as Market Breadth drill-down
- Click any row to open TradingView chart; Esc or backdrop click to close

## Test plan
- [ ] Click any sub-theme name in the Themes Map leaderboard → modal appears with stocks sorted by RS descending
- [ ] Close modal via ✕ button, Esc key, or clicking the backdrop
- [ ] Row click on a stock opens TV chart popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)